### PR TITLE
fix(index.js): wrapp server start logic inside a function

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,17 +6,21 @@ const { connectDb } = require('./db/config.js');
 
 const app = express();
 
-await connectDb();
+const startServer = async () => {
+    await connectDb();
 
-app.use(cors());
-app.use(express.static(path.join(__dirname, 'public')));
-app.use(express.json());
+    app.use(cors());
+    app.use(express.static(path.join(__dirname, 'public')));
+    app.use(express.json());
 
-app.get('*', (req, res) => {
-    res.sendFile(path.join(__dirname, '/public/index.html'));
-});
+    app.get('*', (req, res) => {
+        res.sendFile(path.join(__dirname, '/public/index.html'));
+    });
 
-const PORT = process.env.PORT;
-app.listen(PORT, () => {
-    console.log(`Server running on port: ${PORT}`);
-});
+    const PORT = process.env.PORT;
+    app.listen(PORT, () => {
+        console.log(`Server running on port: ${PORT}`);
+    });
+}
+
+startServer();


### PR DESCRIPTION
By wrapping the logic inside a asynchronous function I was able to use the await keywork with the connectDb function which will enforce the server starting to wait until the connection to the db is done. Also this fixes the error that causes using the awit keyword without a async function.