### PR TITLE
fix(middlewares): switch from array method to mapped method for a better understanding of the errors

### DIFF
--- a/middlewares/manejarResultados.js
+++ b/middlewares/manejarResultados.js
@@ -6,7 +6,7 @@ module.exports.manejarResultados = (req, res, next) => {
     if (!result.isEmpty()) {
         return res.status(400).json({
             ok: false,
-            errors: result.array()
+            errors: result.mapped()
         });
     }
     next();


### PR DESCRIPTION
Changed from array method to mapped method, so errors can be more understandable.